### PR TITLE
Add in remote config and fix browser name config.

### DIFF
--- a/src/main/java/org/nowhere_lights/testframework/drivers/WebDriverFactory.java
+++ b/src/main/java/org/nowhere_lights/testframework/drivers/WebDriverFactory.java
@@ -20,7 +20,7 @@ public class WebDriverFactory {
     public void setWebDriver() {
         if (browser == Browser.CHROME) {
             WebDriverManager.chromedriver().setup();
-            Configuration.browser = "chrome";
+            Configuration.browser = ChromeDriverDesktop.class.getName();
         } else if (browser == Browser.FIREFOX) {
             WebDriverManager.firefoxdriver().setup();
             Configuration.browser = "firefox";
@@ -30,7 +30,7 @@ public class WebDriverFactory {
         } else {
             clearBrowserCache();
             WebDriverManager.chromedriver().setup();
-            Configuration.browser = "chrome";
+            Configuration.browser = ChromeDriverDesktop.class.getName();
         }
 //        Configuration.browserPosition = "790x10";
 //        Configuration.browserSize = "375x812"; //iphone xs viewport
@@ -39,6 +39,11 @@ public class WebDriverFactory {
         String remote = System.getenv("BROWSER_URL");
         if (remote != null) {
             Configuration.remote = remote;
+            if (browser == Browser.FIREFOX) {
+                Configuration.browser = "firefox";
+            } else {
+                Configuration.browser = "chrome";
+            }
         }
     }
 }

--- a/src/main/java/org/nowhere_lights/testframework/drivers/WebDriverFactory.java
+++ b/src/main/java/org/nowhere_lights/testframework/drivers/WebDriverFactory.java
@@ -20,7 +20,7 @@ public class WebDriverFactory {
     public void setWebDriver() {
         if (browser == Browser.CHROME) {
             WebDriverManager.chromedriver().setup();
-            Configuration.browser = ChromeDriverDesktop.class.getName();
+            Configuration.browser = "chrome";
         } else if (browser == Browser.FIREFOX) {
             WebDriverManager.firefoxdriver().setup();
             Configuration.browser = "firefox";
@@ -30,11 +30,15 @@ public class WebDriverFactory {
         } else {
             clearBrowserCache();
             WebDriverManager.chromedriver().setup();
-            Configuration.browser = ChromeDriverDesktop.class.getName();
+            Configuration.browser = "chrome";
         }
 //        Configuration.browserPosition = "790x10";
 //        Configuration.browserSize = "375x812"; //iphone xs viewport
         Configuration.startMaximized = false;
         Configuration.timeout = 10000;
+        String remote = System.getenv("BROWSER_URL");
+        if (remote != null) {
+            Configuration.remote = remote;
+        }
     }
 }


### PR DESCRIPTION
Just a couple minor changes.  The browser name one is required for Docker; it refused to run otherwise.  Let me know if you needed it to be `class.getName()` for another reason and we can make it configurable / find a different solution.

The browser url / remote seemed like it belonged here instead, since it was the only Configuration in a different file.  We can move it back if you want though.